### PR TITLE
Add colab badges

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -59,5 +59,8 @@ defaults:
 sidebars:
 - home_sidebar
 
+
 theme: jekyll-theme-cayman
 baseurl: /self_supervised/
+default_badges:
+  colab: true

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -59,7 +59,6 @@ defaults:
 sidebars:
 - home_sidebar
 
-
 theme: jekyll-theme-cayman
 baseurl: /self_supervised/
 default_badges:


### PR DESCRIPTION
It looks like the main branch doesn't have Colab badges turned on. I think this change would provide them if desired.