### PR TITLE
Corrected Typo in Barlow-twin import in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ learn.fit_flat_cos(100, 1e-2)
 #### Barlow Twins
 
 ```python
-from self_supervised.vision.simclr import *
+from self_supervised.vision.barlow_twins import *
 dls = get_dls(resize, bs)
 # encoder = create_encoder("xresnet34", n_in=3, pretrained=False) # a fastai encoder
 encoder = create_encoder("tf_efficientnet_b4_ns", n_in=3, pretrained=False) # a timm encoder

--- a/nbs/index.ipynb
+++ b/nbs/index.ipynb
@@ -202,7 +202,7 @@
    "metadata": {},
    "source": [
     "```python\n",
-    "from self_supervised.vision.simclr import *\n",
+    "from self_supervised.vision.barlow_twins import *\n",
     "dls = get_dls(resize, bs)\n",
     "# encoder = create_encoder(\"xresnet34\", n_in=3, pretrained=False) # a fastai encoder\n",
     "encoder = create_encoder(\"tf_efficientnet_b4_ns\", n_in=3, pretrained=False) # a timm encoder\n",
@@ -374,6 +374,18 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.6rc1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Two Typography errors were found in the Barlow-twin import of the README file and Index.ipynb notebook.

I have replaced 
`from self_supervised.vision.simclr import *`
with 
`from self_supervised.vision.barlow_twins import *`